### PR TITLE
Adhere to best practices and reformat

### DIFF
--- a/warehouse-backend-example/controller_actor.cpp
+++ b/warehouse-backend-example/controller_actor.cpp
@@ -43,88 +43,81 @@ bool inspect(Insepctor& f, command& x) {
 
 caf::actor
 spawn_controller_actor(caf::actor_system& sys, database_actor db_actor,
-                       caf::net::acceptor_resource<std::byte> events){
-  return sys
-    .spawn(
-      [events,db_actor](caf::event_based_actor* self) mutable {
-      // Stop if the database actor terminates.
-      self->monitor(db_actor, [self](const caf::error& reason) {
-        log::info("controller lost the database actor: {}", reason);
-        self->quit(reason);
-      });
-      // For each buffer pair, we create a new flow ...
-      events.observe_on(self)
-        .for_each(
-          [self, db_actor](auto ev) {
-            log::info("controller added a new client");
-            auto [pull, push] = ev.data();
-            pull
-              .observe_on(self)
-              // ... that converts the lines to commands ...
-              .transform(caf::flow::byte::split_as_utf8_at('\n'))
-              .map([self](const caf::cow_string& line) {
-                log::debug("controller received line: {}", line.str());
-                caf::json_reader reader;
-                if (!reader.load(line.str())) {
-                  log::error("controller failed to parse JSON: {}",
-                             reader.get_error());
-                  return std::shared_ptr<command>{}; // Invalid JSON.
-                }
-                auto ptr = std::make_shared<command>();
-                if (!reader.apply(*ptr))
-                  return std::shared_ptr<command>{}; // Not a command.
-                return ptr;
-              })
-              .concat_map(
-                [self, db_actor](std::shared_ptr<command> ptr) {
-                  // If the `map` step failed, inject an error message.
-                  if (ptr == nullptr || !ptr->valid()) {
-                    auto str = R"_({"error":"invalid command"})_"s;
-                    return self->make_observable()
-                      .just(caf::cow_string{std::move(str)})
-                      .as_observable();
-                  }
-                  // Send the command to the database actor and convert the
-                  // result message into an observable.
-                  caf::flow::observable<int32_t> result;
-                  if (ptr->type == "inc") {
-                    result = self->mail(inc_atom_v, ptr->id, ptr->amount)
-                               .request(db_actor, 1s)
-                               .as_observable();
-                  } else {
-                    result = self->mail(dec_atom_v, ptr->id, ptr->amount)
-                               .request(db_actor, 1s)
-                               .as_observable();
-                  }
-                  // On error, we return an error message to the client.
-                  return result
-                    .map([ptr](int32_t res) {
-                      log::debug("controller received result for {} -> {}",
-                                 *ptr, res);
-                      auto str = R"_({"result":)_"s;
-                      str += std::to_string(res);
-                      str += '}';
-                      return caf::cow_string{std::move(str)};
-                    })
-                    .on_error_return([ptr](const caf::error& what) {
-                      log::debug("controller received an error for {} -> {}",
-                                 *ptr, what);
-                      auto str = R"_({"error":")_"s;
-                      str += to_string(what);
-                      str += R"_("})_";
-                      auto res = caf::cow_string{std::move(str)};
-                      return caf::expected<caf::cow_string>{std::move(res)};
-                    })
-                    .as_observable();
-                })
-              // ... disconnects if the client is too slow ...
-              .on_backpressure_buffer(32)
-              // ... and pushes the results back to the client as bytes.
-              .transform(caf::flow::string::to_chars("\n"))
-              .do_finally(
-                [] { log::info("controller lost connection to a client"); })
-              .map([](char ch) { return static_cast<std::byte>(ch); })
-              .subscribe(push);
-          });
-      });
+                       caf::net::acceptor_resource<std::byte> events) {
+  return sys.spawn([events, db_actor](caf::event_based_actor* self) mutable {
+    // Stop if the database actor terminates.
+    self->monitor(db_actor, [self](const caf::error& reason) {
+      log::info("controller lost the database actor: {}", reason);
+      self->quit(reason);
+    });
+    // For each buffer pair, we create a new flow ...
+    events.observe_on(self).for_each([self, db_actor](auto ev) {
+      log::info("controller added a new client");
+      auto [pull, push] = ev.data();
+      pull
+        .observe_on(self)
+        // ... that converts the lines to commands ...
+        .transform(caf::flow::byte::split_as_utf8_at('\n'))
+        .map([self](const caf::cow_string& line) {
+          log::debug("controller received line: {}", line.str());
+          caf::json_reader reader;
+          if (!reader.load(line.str())) {
+            log::error("controller failed to parse JSON: {}",
+                       reader.get_error());
+            return std::shared_ptr<command>{}; // Invalid JSON.
+          }
+          auto ptr = std::make_shared<command>();
+          if (!reader.apply(*ptr))
+            return std::shared_ptr<command>{}; // Not a command.
+          return ptr;
+        })
+        .concat_map([self, db_actor](std::shared_ptr<command> ptr) {
+          // If the `map` step failed, inject an error message.
+          if (ptr == nullptr || !ptr->valid()) {
+            auto str = R"_({"error":"invalid command"})_"s;
+            return self->make_observable()
+              .just(caf::cow_string{std::move(str)})
+              .as_observable();
+          }
+          // Send the command to the database actor and convert the
+          // result message into an observable.
+          caf::flow::observable<int32_t> result;
+          if (ptr->type == "inc") {
+            result = self->mail(inc_atom_v, ptr->id, ptr->amount)
+                       .request(db_actor, 1s)
+                       .as_observable();
+          } else {
+            result = self->mail(dec_atom_v, ptr->id, ptr->amount)
+                       .request(db_actor, 1s)
+                       .as_observable();
+          }
+          // On error, we return an error message to the client.
+          return result
+            .map([ptr](int32_t res) {
+              log::debug("controller received result for {} -> {}", *ptr, res);
+              auto str = R"_({"result":)_"s;
+              str += std::to_string(res);
+              str += '}';
+              return caf::cow_string{std::move(str)};
+            })
+            .on_error_return([ptr](const caf::error& what) {
+              log::debug("controller received an error for {} -> {}", *ptr,
+                         what);
+              auto str = R"_({"error":")_"s;
+              str += to_string(what);
+              str += R"_("})_";
+              auto res = caf::cow_string{std::move(str)};
+              return caf::expected<caf::cow_string>{std::move(res)};
+            })
+            .as_observable();
+        })
+        // ... disconnects if the client is too slow ...
+        .on_backpressure_buffer(32)
+        // ... and pushes the results back to the client as bytes.
+        .transform(caf::flow::string::to_chars("\n"))
+        .do_finally([] { log::info("controller lost connection to a client"); })
+        .map([](char ch) { return static_cast<std::byte>(ch); })
+        .subscribe(push);
+    });
+  });
 }

--- a/warehouse-backend-example/database.cpp
+++ b/warehouse-backend-example/database.cpp
@@ -80,7 +80,7 @@ ec database::insert(const item& new_item) {
     return ec::database_inaccessible;
   if (sqlite3_bind_int(stmt, 1, new_item.id) != SQLITE_OK
       || sqlite3_bind_text(stmt, 2, new_item.name.c_str(), -1, SQLITE_STATIC)
-             != SQLITE_OK
+           != SQLITE_OK
       || sqlite3_bind_int(stmt, 3, new_item.price) != SQLITE_OK
       || sqlite3_bind_int(stmt, 4, new_item.available) != SQLITE_OK) {
     sqlite3_finalize(stmt);

--- a/warehouse-backend-example/database.hpp
+++ b/warehouse-backend-example/database.hpp
@@ -40,16 +40,19 @@ public:
   [[nodiscard]] std::optional<item> get(int32_t id);
 
   /// Inserts a new item into the database.
-  /// @returns `true` on success, `false` if the item already exists.
+  /// @returns `ec::nil` on success, an error code otherwise.
   [[nodiscard]] ec insert(const item& new_item);
 
   /// Increments the available count of an item.
+  /// @returns `ec::nil` on success, an error code otherwise.
   [[nodiscard]] ec inc(int32_t id, int32_t amount);
 
   /// Decrements the available count of an item.
+  /// @returns `ec::nil` on success, an error code otherwise.
   [[nodiscard]] ec dec(int32_t id, int32_t amount);
 
   /// Deletes an item from the database.
+  /// @returns `ec::nil` on success, an error code otherwise.
   [[nodiscard]] ec del(int32_t id);
 
 private:

--- a/warehouse-backend-example/database_actor.hpp
+++ b/warehouse-backend-example/database_actor.hpp
@@ -3,27 +3,26 @@
 #pragma once
 
 #include "database.hpp"
+#include "item.hpp"
 #include "types.hpp"
-
-#include <caf/fwd.hpp>
 
 #include <memory>
 
-using item_event = std::shared_ptr<const item>;
+struct database_trait {
+  using signatures = caf::type_list<
+    // Retrieves an item from the database.
+    caf::result<item>(get_atom, int32_t),
+    // Adds a new item to the database.
+    caf::result<void>(add_atom, int32_t, int32_t, std::string),
+    // Increments the available count of an item.
+    caf::result<int32_t>(inc_atom, int32_t, int32_t),
+    // Decrements the available count of an item.
+    caf::result<int32_t>(dec_atom, int32_t, int32_t),
+    // Deletes an item from the database.
+    caf::result<void>(del_atom, int32_t)>;
+};
 
-using item_events = caf::async::publisher<item_event>;
-
-using database_actor = caf::typed_actor<
-  // Retrieves an item from the database.
-  caf::result<item>(get_atom, int32_t),
-  // Adds a new item to the database.
-  caf::result<void>(add_atom, int32_t, int32_t, std::string),
-  // Increments the available count of an item.
-  caf::result<int32_t>(inc_atom, int32_t, int32_t),
-  // Decrements the available count of an item.
-  caf::result<int32_t>(dec_atom, int32_t, int32_t),
-  // Deletes an item from the database.
-  caf::result<void>(del_atom, int32_t)>;
+using database_actor = caf::typed_actor<database_trait>;
 
 std::pair<database_actor, item_events>
 spawn_database_actor(caf::actor_system& sys, database_ptr db);

--- a/warehouse-backend-example/item.hpp
+++ b/warehouse-backend-example/item.hpp
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <caf/async/fwd.hpp>
+
 #include <cstdint>
 #include <string>
 
@@ -11,6 +13,10 @@ struct item {
   int32_t available;
   std::string name;
 };
+
+using item_event = std::shared_ptr<const item>;
+
+using item_events = caf::async::publisher<item_event>;
 
 template <class Inspector>
 bool inspect(Inspector& f, item& x) {


### PR DESCRIPTION
- Fix documentation
- Avoid unnecessary use of a future
- Apply `clang-format` to the repo
- Use a trait class to define the `database_actor`